### PR TITLE
Merge changes for Xperia 1V's dolby and fix curroption issues

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -21,7 +21,6 @@ AB_OTA_PARTITIONS += \
     boot \
     dtbo \
     product \
-    recovery \
     system \
     system_ext \
     vbmeta \

--- a/audio/audio_effects.xml
+++ b/audio/audio_effects.xml
@@ -88,7 +88,6 @@
         <library name="dnnr" path="libdnnrwrapper.so"/>
         <!--DOLBY DAP-->
         <library name="dap" path="libswdap.so"/>
-        <library name="dvl" path="libdlbvol.so"/>
         <!--DOLBY GAME-->
         <library name="gamedap" path="libswgamedap.so"/>
         <!--DOLBY VQE-->
@@ -166,12 +165,6 @@
         <effect name="DNNR" library="dnnr" uuid="fa3cce18-254f-4573-bcec-6bd279476034"/>
         <!--DOLBY DAP-->
         <effect name="dap" library="dap" uuid="9d4921da-8225-4f29-aefa-39537a04bcaa"/>
-        <effect name="dlb_music_listener" library="dvl" uuid="40f66c8b-5aa5-4345-8919-53ec431aaa98"/>
-        <effect name="dlb_ring_listener" library="dvl" uuid="21d14087-558a-4f21-94a9-5002dce64bce"/>
-        <effect name="dlb_alarm_listener" library="dvl" uuid="6aff229c-30c6-4cc8-9957-dbfe5c1bd7f6"/>
-        <effect name="dlb_system_listener" library="dvl" uuid="874db4d8-051d-4b7b-bd95-a3bebc837e9e"/>
-        <effect name="dlb_notification_listener" library="dvl" uuid="1f0091e3-6ad8-40fe-9b09-5948f9a26e7e"/>
-        <effect name="dlb_voice_call_listener" library="dvl" uuid="58d13383-b41d-05df-d94e-bb23db293260"/>
         <!--DOLBY GAME-->
         <effect name="gamedap" library="gamedap" uuid="3783c334-d3a0-4d13-874f-0032e5fb80e2"/>
         <!--DOLBY VQE-->
@@ -182,7 +175,6 @@
             <!-- Disable volume listener
             <apply effect="music_helper"/>
             -->
-            <apply effect="dlb_music_listener"/>
         </stream>
         <stream type="ring">
             <!-- Disable volume listener

--- a/audio/audio_policy_configuration.xml
+++ b/audio/audio_policy_configuration.xml
@@ -232,6 +232,13 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                              samplingRates="8000 11025 12000 16000 22050 24000 32000 44100 48000"
                              channelMasks="AUDIO_CHANNEL_IN_MONO AUDIO_CHANNEL_IN_STEREO AUDIO_CHANNEL_IN_FRONT_BACK AUDIO_CHANNEL_INDEX_MASK_3"/>
                 </mixPort>
+                <!--Spatial Audio-->
+                <!-- Dolby Spatializer -->
+                <mixPort name="spatial output" role="source" flags="AUDIO_OUTPUT_FLAG_SPATIALIZER">
+                    <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                             samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+                </mixPort>
+                <!-- Dolby Spatializer -->
                 <mixPort name="hifi_input" role="sink" />
                 <mixPort name="fast input" role="sink"
                          flags="AUDIO_INPUT_FLAG_FAST">

--- a/configs/media_codecs_kona_vendor.xml
+++ b/configs/media_codecs_kona_vendor.xml
@@ -479,4 +479,5 @@ Only the three quirks included above are recognized at this point:
     </Decoders>
     <Include href="media_codecs_google_video.xml" />
     <Include href="media_codecs_dolby_audio.xml" />
+    <Include href="media_codecs_sony_c2_audio.xml" />
 </MediaCodecs>

--- a/configs/powerhint.json
+++ b/configs/powerhint.json
@@ -27,15 +27,6 @@
       "ResetOnInit": true
     },
     {
-      "Name": "CPULittleClusterGovernor",
-      "Path": "/sys/devices/system/cpu/cpufreq/policy0/scaling_governor",
-      "Values": [
-        "schedutil",
-        "powersave"
-      ],
-      "ResetOnInit": true
-    },
-    {
       "Name": "CPUBigClusterMaxFreq",
       "Path": "/sys/devices/system/cpu/cpu4/cpufreq/scaling_max_freq",
       "Values": [
@@ -65,15 +56,6 @@
       "ResetOnInit": true
     },
     {
-      "Name": "CPUBigClusterGovernor",
-      "Path": "/sys/devices/system/cpu/cpufreq/policy4/scaling_governor",
-      "Values": [
-        "schedutil",
-        "powersave"
-      ],
-      "ResetOnInit": true
-    },
-    {
       "Name": "CPUBigPlusClusterMaxFreq",
       "Path": "/sys/devices/system/cpu/cpu7/cpufreq/scaling_max_freq",
       "Values": [
@@ -99,15 +81,6 @@
         "1286400"
       ],
       "DefaultIndex": 3,
-      "ResetOnInit": true
-    },
-    {
-      "Name": "CPUBigPlusClusterGovernor",
-      "Path": "/sys/devices/system/cpu/cpufreq/policy7/scaling_governor",
-      "Values": [
-        "schedutil",
-        "powersave"
-      ],
       "ResetOnInit": true
     },
     {
@@ -451,24 +424,6 @@
       "Node": "CPULittleClusterMinFreq",
       "Duration": 3000,
       "Value": "9999999"
-    },
-    {
-      "PowerHint": "INTERACTIVE",
-      "Node": "CPULittleClusterGovernor",
-      "Duration": 0,
-      "Value": "schedutil"
-    },
-    {
-      "PowerHint": "INTERACTIVE",
-      "Node": "CPUBigClusterGovernor",
-      "Duration": 0,
-      "Value": "schedutil"
-    },
-    {
-      "PowerHint": "INTERACTIVE",
-      "Node": "CPUBigPlusClusterGovernor",
-      "Duration": 0,
-      "Value": "schedutil"
     },
     {
       "PowerHint": "LAUNCH",

--- a/configs/powerhint.json
+++ b/configs/powerhint.json
@@ -158,6 +158,15 @@
       "ResetOnInit": true
     },
     {
+      "Name": "PMQoSCpuDmaLatency",
+      "Path": "/dev/cpu_dma_latency",
+      "Values": [
+        "2c",
+        "66"
+      ],
+      "HoldFd": true
+    },
+    {
       "Name": "CDSchedtuneBoost",
       "Path": "/dev/stune/camera-daemon/schedtune.boost",
       "Values": [
@@ -290,6 +299,15 @@
       "Path": "vendor.powerhal.state",
       "Values": [
         "SUSTAINED_PERFORMANCE",
+        ""
+      ],
+      "Type": "Property"
+    },
+    {
+      "Name": "PowerHALAudioState",
+      "Path": "vendor.powerhal.audio",
+      "Values": [
+        "AUDIO_STREAMING_LOW_LATENCY",
         ""
       ],
       "Type": "Property"
@@ -754,6 +772,24 @@
       "Node": "CPULittleClusterMinFreq",
       "Duration": 1000,
       "Value": "9999999"
+    },
+    {
+      "PowerHint": "AUDIO_LAUNCH",
+      "Node": "PMQoSCpuDmaLatency",
+      "Duration": 2000,
+      "Value": "2c"
+    },
+    {
+      "PowerHint": "AUDIO_STREAMING_LOW_LATENCY",
+      "Node": "PowerHALAudioState",
+      "Duration": 0,
+      "Value": "AUDIO_STREAMING_LOW_LATENCY"
+    },
+    {
+      "PowerHint": "AUDIO_STREAMING_LOW_LATENCY",
+      "Node": "PMQoSCpuDmaLatency",
+      "Duration": 0,
+      "Value": "2c"
     },
     {
       "PowerHint": "EXPENSIVE_RENDERING",

--- a/edo.mk
+++ b/edo.mk
@@ -198,9 +198,12 @@ PRODUCT_PACKAGES += \
 
 # Boot control
 PRODUCT_PACKAGES += \
-    android.hardware.boot@1.2-impl-qti \
-    android.hardware.boot@1.2-impl-qti.recovery \
-    android.hardware.boot@1.2-service
+    android.hardware.boot@1.1-impl-qti \
+    android.hardware.boot@1.1-impl-qti.recovery \
+    android.hardware.boot@1.1-service
+
+PRODUCT_PACKAGES_DEBUG += \
+    bootctl
 
 # Camera
 PRODUCT_PACKAGES += \

--- a/edo.mk
+++ b/edo.mk
@@ -168,7 +168,6 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/audio/audio_io_policy.conf:$(TARGET_COPY_OUT_VENDOR)/etc/audio_io_policy.conf \
     $(LOCAL_PATH)/audio/audio_platform_info_intcodec.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_platform_info_intcodec.xml \
     $(LOCAL_PATH)/audio/audio_tuning_mixer.txt:$(TARGET_COPY_OUT_VENDOR)/etc/audio_tuning_mixer.txt \
-    $(LOCAL_PATH)/audio/dax-default.xml:$(TARGET_COPY_OUT_VENDOR)/etc/dolby/dax-default.xml \
     $(LOCAL_PATH)/audio/sound_trigger_mixer_paths.xml:$(TARGET_COPY_OUT_VENDOR)/etc/sound_trigger_mixer_paths.xml \
     $(LOCAL_PATH)/audio/sound_trigger_platform_info.xml:$(TARGET_COPY_OUT_VENDOR)/etc/sound_trigger_platform_info.xml \
     $(LOCAL_PATH)/audio/sound_trigger_platform_info_no_SVA.xml:$(TARGET_COPY_OUT_VENDOR)/etc/sound_trigger_platform_info_no_SVA.xml \

--- a/edo.mk
+++ b/edo.mk
@@ -556,16 +556,12 @@ PRODUCT_BOOT_JARS += \
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/configs/privapp-permissions-wfd.xml:$(TARGET_COPY_OUT_SYSTEM)/etc/permissions/privapp-permissions-wfd.xml
 
-# Xperia Modules
-include hardware/sony/XperiaModules.mk
-
 # Xperia Modules - Flags
 TARGET_SUPPORTS_CREATOR_MODE := true
 TARGET_SUPPORTS_SOUND_ENHANCEMENT_DTS := false
 TARGET_SUPPORTS_EUICC := false
 
 # Extras
-$(call inherit-product, vendor/sony/extra/extra.mk)
 TARGET_SHIPS_SONY_CAMERA := true
 TARGET_SHIPS_SONY_APPS := true
 TARGET_SUPPORTS_GAME_CONTROLLERS := true
@@ -573,5 +569,11 @@ TARGET_SUPPORTS_GAME_CONTROLLERS := true
 # Extras and XperiaModules Combined
 TARGET_SUPPORTS_SOUND_ENHANCEMENT := true
 TARGET_SHIPS_SOUND_ENHANCEMENT := true
+
+# Xperia Modules
+$(call inherit-product, hardware/sony/XperiaModules.mk)
+
+# Extras Repo
+$(call inherit-product, vendor/sony/extra/extra.mk)
 
 PRODUCT_USE_DYNAMIC_PARTITIONS := true

--- a/edo.mk
+++ b/edo.mk
@@ -561,7 +561,6 @@ include hardware/sony/XperiaModules.mk
 
 # Xperia Modules - Flags
 TARGET_SUPPORTS_CREATOR_MODE := true
-TARGET_SUPPORTS_SOUND_ENHANCEMENT := true
 TARGET_SUPPORTS_SOUND_ENHANCEMENT_DTS := false
 TARGET_SUPPORTS_EUICC := false
 


### PR DESCRIPTION
The curroption issues were caused by updating to boot control hal 1.2

Revert back to 1.1